### PR TITLE
Patch for jQuery HTML5 placeholder shim so it works with Drupal 7 (among other things).

### DIFF
--- a/jquery.html5-placeholder-shim.js
+++ b/jquery.html5-placeholder-shim.js
@@ -81,8 +81,8 @@
 
 })(jQuery);
 
-$(document).add(window).bind('ready load', function() {
-  if ($.placeholder) {
-    $.placeholder.shim();
+jQuery(document).add(window).bind('ready load', function() {
+  if (jQuery.placeholder) {
+    jQuery.placeholder.shim();
   }
 });


### PR DESCRIPTION
Do not assume jQuery has been initialised to the $ variable.  Drupal 7 requires this, among other things
