### PR TITLE
Fix to handle removal of text inputs without errors.

### DIFF
--- a/jquery.html5-placeholder-shim.js
+++ b/jquery.html5-placeholder-shim.js
@@ -30,6 +30,13 @@
           width: $(target).width()
         };
       }
+      function adjustToResizing(label) {
+      	var $target = label.data('target');
+      	if(typeof $target !== "undefined") {
+          label.css(calcPositionCss($target));
+          $(window).one("resize", function () { adjustToResizing(label); });
+        }
+      }
       return this.each(function() {
         var $this = $(this);
 
@@ -83,11 +90,7 @@
             }).blur(function() {
               ol[$this.val().length ? 'hide' : 'show']();
             }).triggerHandler('blur');
-          $(window)
-            .resize(function() {
-              var $target = ol.data('target');
-              ol.css(calcPositionCss($target));
-            });
+          $(window).one("resize", function () { adjustToResizing(ol); });
         }
       });
     }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Just include the ``jquery.html-placeholder-shim.js`` script into your document h
       <script type='text/javascript' src='jquery/html5-placeholder-shim.js'></script>
     </head>
 
-The script will automatically execute itself on the ``$(document).ready`` event.
+The script will automatically execute itself on the ``$(document).ready`` event and can be re-executed at any time (for example, to add placeholders to text boxes created during dynamic changes to the page) by running ``$.placeholder.shim();``.
 
 ## HTML5 placeholder Example:
 

--- a/test.html
+++ b/test.html
@@ -67,6 +67,7 @@ $(function(){
 		<h2>Basic Examples</h2>
 		<a href="#" onclick="$('#cont').toggle();return false;">hide form</a>
 		<a href="#" onclick="$('#medium').toggle();$.placeholder.shim();return false;">hide medium row</a>
+		<a href="#" id="remove" onclick="this.onclick='';$('#large').remove();window.resizeTo($(window).width(), $(window).height());$.placeholder.shim();return false;">remove large row and resize window</a>
 		<div id="cont" >
 			<div>
 				<label>small</label>
@@ -78,7 +79,7 @@ $(function(){
 				<input type="text" placeholder="placeholder" class="medium" />
 				<input type="text" placeholder="placeholder" value="value" class="medium" />
 			</div>
-			<div>	
+			<div id="large">	
 				<label>large</label>
 				<input type="text" placeholder="placeholder" class="large" />
 				<input type="text" placeholder="placeholder" value="value" class="large" />


### PR DESCRIPTION
Removing any text inputs from the DOM after this code applied placeholder labels to them resulted in errors every time the window was resized, because it left behind phantom window.resize event handlers that referenced objects which were no longer valid. Fixed this, to allow better use of this shim with pages using dynamic HTML modifications.
