### PR TITLE
Changing placeholder hide on focus to keydown

### DIFF
--- a/jquery.html5-placeholder-shim.js
+++ b/jquery.html5-placeholder-shim.js
@@ -85,9 +85,10 @@
             .insertBefore(this);
           $this
             .data('placeholder',ol)
-            .focus(function(){
-              ol.hide();
-            }).blur(function() {
+						.keydown(function(){
+							ol.hide();
+						})
+						.blur(function() {
               ol[$this.val().length ? 'hide' : 'show']();
             }).triggerHandler('blur');
           $(window).one("resize", function () { adjustToResizing(ol); });


### PR DESCRIPTION
Hello, Philip

Thank you for cool shim, that really light weight, clear and works great.
Only one thing, by default in modern browsers placeholder text hides on keypress event and you have it on focus. I propose to you change it because if page have autofocus on start, placeholder not displayed and it's bad for ux.

Best regards, Bogdan
