### PR TITLE
Added check if input is disabled when setting the focus.

### DIFF
--- a/jquery.html5-placeholder-shim.js
+++ b/jquery.html5-placeholder-shim.js
@@ -82,7 +82,9 @@
             .attr('for', this.id)
             .data('target',$this)
             .click(function(){
-              $(this).data('target').focus();
+                if (!$(this).data('target').is(':disabled')) {
+                    $(this).data('target').focus();
+                }
             })
             .insertBefore(this);
           $this


### PR DESCRIPTION
Setting the focus to a disabled element can cause an error in IE7 and
IE8.
