### PR TITLE
remove placeholder on autocomplete

### DIFF
--- a/jquery.html5-placeholder-shim.js
+++ b/jquery.html5-placeholder-shim.js
@@ -88,14 +88,15 @@
                 }
             })
             .insertBefore(this);
-          $this
-            .data('placeholder',ol)
-						.keydown(function(){
-							ol.hide();
-						})
-						.blur(function() {
-              ol[$this.val().length ? 'hide' : 'show']();
-            }).triggerHandler('blur');
+            $this
+                .data('placeholder', ol)
+                .on('keydown', function () {
+                    ol.hide();
+                })
+                .on('blur change', function () {
+                    ol[$this.val().length ? 'hide' : 'show']();
+                })
+                .triggerHandler('blur');
           $(window).one("resize", function () { adjustToResizing(ol); });
         }
       });


### PR DESCRIPTION
Removing placeholder when browser autofill field (Tested on IE9, IE7-8  don't dispatch the change event)
